### PR TITLE
Fix UniqueField during updates when field value hasn't changed

### DIFF
--- a/lux/extensions/odm/forms.py
+++ b/lux/extensions/odm/forms.py
@@ -1,5 +1,7 @@
 import logging
 
+from sqlalchemy.inspection import inspect
+
 from lux import forms
 from lux.forms.fields import MultipleMixin
 
@@ -69,14 +71,20 @@ class UniqueField:
     def __call__(self, value, bfield):
         model = self.model or bfield.form.model
         field = self.field or bfield.name
+        previous_state = bfield.form.previous_state
         assert model, 'model not available'
         assert field, 'field not available'
         app = bfield.request.app
         # Get a reference to the object data mapper
         odm = app.odm()
         model = odm[model]
+        pkey = inspect(model).primary_key
         with odm.begin() as session:
             q = session.query(model).filter_by(**{field: value})
+            if previous_state:
+                for pkey_col in pkey:
+                    q = q.filter(pkey_col != getattr(previous_state,
+                                                     pkey_col.name))
             if q.count():
                 raise forms.ValidationError(
                     self.validation_error.format(value))

--- a/lux/extensions/odm/views.py
+++ b/lux/extensions/odm/views.py
@@ -211,7 +211,8 @@ class CRUD(RestRouter):
 
             if backend.has_permission(request, model.name, rest.UPDATE):
                 data, files = request.data_and_files()
-                form = form_class(request, data=data, files=files)
+                form = form_class(request, data=data, files=files,
+                                  previous_state=instance)
                 if form.is_valid(exclude_missing=True):
                     instance = self.update_model(request, instance,
                                                  form.cleaned_data)

--- a/lux/forms/form.py
+++ b/lux/forms/form.py
@@ -102,7 +102,9 @@ class Form(metaclass=FormType):
     :parameter files: dictionary type object containing files to upload.
     :parameter initial: set the :attr:`initial` attribute.
     :parameter prefix: set the :attr:`prefix` attribute.
-    :parameter instance: An optional instance of a model class.
+    :parameter previous_state:  An optional instance of a model class,
+                                representing the state before changes
+                                have been made.
     :parameter request: Optional client request.
 
     .. attribute:: is_bound
@@ -148,9 +150,10 @@ class Form(metaclass=FormType):
 
         Default: ``{}``.
 
-    .. attribute:: instance
+    .. attribute:: previous_state
 
-        An optional instance of a model.
+        An optional instance of a model, representing the state before changes
+        have been made.
 
         Default: ``None``.
 
@@ -159,7 +162,7 @@ class Form(metaclass=FormType):
     model = None
 
     def __init__(self, request=None, data=None, files=None, initial=None,
-                 prefix=None):
+                 prefix=None, previous_state=None):
         self.request = request
         self.is_bound = data is not None or files is not None
         if self.is_bound:
@@ -183,6 +186,7 @@ class Form(metaclass=FormType):
         self.forms = []
         if not self.is_bound:
             self._fill_initial()
+        self.previous_state = previous_state
         if request:
             request.app.fire('on_form', self)
 


### PR DESCRIPTION
Fixes UniqueField validator during updates when a field value is supplied for the unique field but hasn't changed. Previously was failing as it thought the value had already been used.

Also adds more tests.