### PR TITLE
show errors in checkbox fields

### DIFF
--- a/luxjs/forms/form.js
+++ b/luxjs/forms/form.js
@@ -287,7 +287,8 @@
                     });
 
                     label.append(input).append(span);
-                    return this.onChange(scope, element.append(label));
+                    element.append(label);
+                    return this.onChange(scope, this.inputError(scope, element));
                 },
                 //
                 checkbox: function (scope) {


### PR DESCRIPTION
This is a fix to display errors in checkbox fields.

- Ref to: [bmll-portal-#128](https://github.com/bmlltech/bmll-portal/issues/128) 