### PR TITLE
Don't use container-fluid for fluid navbar as it adds padding

### DIFF
--- a/luxjs/nav/nav.js
+++ b/luxjs/nav/nav.js
@@ -84,7 +84,7 @@
                     navbar.url = '/';
                 if (!navbar.themeTop)
                     navbar.themeTop = navbar.theme;
-                navbar.container = navbar.fluid ? 'container-fluid' : 'container';
+                navbar.container = navbar.fluid ? '' : 'container';
 
                 this.maybeCollapse(navbar);
 


### PR DESCRIPTION
Removes the non-clickable space to the left of the menu button and the right of the log out button on pages with the fluid navbar.