### PR TITLE
Make user name field use SlugField and disable browser autocorrect on SlugFields

### DIFF
--- a/lux/extensions/auth/forms.py
+++ b/lux/extensions/auth/forms.py
@@ -92,7 +92,7 @@ class GroupForm(forms.Form):
 
 class UserForm(forms.Form):
     id = forms.HiddenField(required=False)
-    username = forms.CharField()
+    username = forms.SlugField()
     email = forms.EmailField(required=False)
     first_name = forms.CharField(required=False)
     last_name = forms.CharField(required=False)
@@ -108,7 +108,7 @@ class CreateUserForm(PasswordForm):
     '''Form for creating a new user form username, email and password
     '''
     model = 'user'
-    username = forms.CharField(required=True,
+    username = forms.SlugField(required=True,
                                validator=odm.UniqueField(),
                                maxlength=30)
     email = forms.EmailField(required=True,

--- a/lux/extensions/rest/forms.py
+++ b/lux/extensions/rest/forms.py
@@ -10,7 +10,7 @@ __all__ = ['LoginForm',
 class LoginForm(forms.Form):
     '''The Standard login form'''
     error_message = 'Incorrect username or password'
-    username = forms.CharField(required=True, maxlength=30)
+    username = forms.SlugField(required=True, maxlength=30)
     password = forms.PasswordField(required=True, maxlength=128)
 
 
@@ -28,7 +28,7 @@ class PasswordForm(forms.Form):
 
 
 class CreateUserForm(PasswordForm):
-    username = forms.CharField(required=True, maxlength=30)
+    username = forms.SlugField(required=True, maxlength=30)
     email = forms.EmailField(required=True)
 
 

--- a/lux/forms/fields.py
+++ b/lux/forms/fields.py
@@ -405,6 +405,17 @@ class FileField(MultipleMixin, Field):
 
 
 class SlugField(CharField):
+    validation_error = ('Only lower case, alphanumeric characters and '
+                        'hyphens are allowed')
+
+    def getattrs(self, form=None):
+        attrs = super().getattrs(form)
+        attrs['autocorrect'] = 'off'
+        attrs['autocapitalize'] = 'none'
+        return attrs
+
     def _clean(self, value, field):
         value = super()._clean(value, field)
-        return slugify(value)
+        if slugify(value) != value:
+            raise ValidationError(self.validation_error)
+        return value

--- a/lux/utils/test.py
+++ b/lux/utils/test.py
@@ -21,9 +21,9 @@ logger = logging.getLogger('lux.test')
 
 
 def randomname(prefix=None, len=8):
-    '''Generate a random name with a prefix (default to ``luxtest_``)
+    '''Generate a random name with a prefix (default to ``luxtest-``)
     '''
-    prefix = prefix if prefix is not None else 'luxtest_'
+    prefix = prefix if prefix is not None else 'luxtest-'
     name = random_string(min_len=len, max_len=len,
                          characters=string.ascii_letters)
     return ('%s%s' % (prefix, name)).lower()

--- a/luxjs/forms/form.js
+++ b/luxjs/forms/form.js
@@ -99,7 +99,8 @@
                                   function (log, $http, $document, $templateCache, formDefaults, formElements) {
             //
             var baseAttributes = ['id', 'name', 'title', 'style'],
-                inputAttributes = extendArray([], baseAttributes, ['disabled', 'readonly', 'type', 'value', 'placeholder']),
+                inputAttributes = extendArray([], baseAttributes, ['disabled', 'readonly', 'type', 'value', 'placeholder',
+                                                                  'autocapitalize', 'autocorrect']),
                 textareaAttributes = extendArray([], baseAttributes, ['disabled', 'readonly', 'placeholder', 'rows', 'cols']),
                 buttonAttributes = extendArray([], baseAttributes, ['disabled']),
                 // Don't include action in the form attributes

--- a/tests/auth/sqlite.py
+++ b/tests/auth/sqlite.py
@@ -228,7 +228,8 @@ class TestSqlite(test.AppTestCase, AuthUtils):
                                               token=token)
 
         self.assertValidationError(request.response, 'name',
-                                   'abcd not available')
+                                   'Only lower case, alphanumeric characters '
+                                   'and hyphens are allowed')
 
     def test_login_fail(self):
         data = {'username': 'jdshvsjhvcsd',


### PR DESCRIPTION
Sets `autocorrect="off"` and `autocapitalize="none"` for `SlugField`s.

Changes user name to be a `SlugField`.