### PR TITLE
Fixes sidebar transition on page load

### DIFF
--- a/lux/extensions/admin/sidebar.py
+++ b/lux/extensions/admin/sidebar.py
@@ -48,6 +48,12 @@ def add_css(all):
         width=pc(100),
         overflow_x='hidden')
 
+    css('.preload *',
+        _webkit_transition='none !important',
+        _moz_transition='none !important',
+        _ms_transition='none !important',
+        _o_transition='none !important')
+
     css('.sidebar-body',
         position='relative')
 

--- a/luxjs/nav/sidebar.js
+++ b/luxjs/nav/sidebar.js
@@ -35,6 +35,8 @@
             function initSideBar (sidebars, element, sidebar, position) {
                 sidebar = angular.extend({}, sidebarDefaults, sidebar);
                 sidebar.position = position;
+                // preload removes transitions
+                element.addClass('preload');
                 if (!sidebar.collapse)
                     element.addClass('sidebar-open-' + position);
                 if (sidebar.sections) {
@@ -133,9 +135,9 @@
         //
         //  Directive for the sidebar
         .directive('sidebar', ['$compile', 'sidebarService', 'navService', 'sidebarTemplate',
-                               'navbarTemplate', '$templateCache',
+                               'navbarTemplate', '$templateCache', '$timeout',
                         function ($compile, sidebarService, navService, sidebarTemplate, navbarTemplate,
-                                  $templateCache) {
+                                  $templateCache, $timeout) {
             //
             return {
                 restrict: 'AE',
@@ -166,6 +168,12 @@
                                 lux.querySelector(element, '.content-wrapper').append(inner);
                             else
                                 element.after(inner);
+
+                            if (document.readyState === 'complete') {
+                                $timeout(function() {
+                                    element.removeClass('preload');
+                                });
+                            }
                         }
                     };
                 }


### PR DESCRIPTION
We needed to force sidebar to add transitions only after page load in order to solve 
issue: `sidebar quickly opens and closes on page load`