### PR TITLE
Explicitly specify config/language for :search operator

### DIFF
--- a/lux/extensions/odm/__init__.py
+++ b/lux/extensions/odm/__init__.py
@@ -36,7 +36,10 @@ class Extension(lux.Extension):
         Parameter('DATABASE_SESSION_SIGNALS', True,
                   'Register event handlers for database session'),
         Parameter('MIGRATIONS', None,
-                  'Dictionary for mapping alembic settings')
+                  'Dictionary for mapping alembic settings'),
+        Parameter('DEFAULT_TEXT_SEARCH_CONFIG', 'english',
+                  'Default config/language for :search operator full-text '
+                  'search')
     ]
 
     def on_config(self, app):

--- a/lux/extensions/odm/__init__.py
+++ b/lux/extensions/odm/__init__.py
@@ -38,8 +38,8 @@ class Extension(lux.Extension):
         Parameter('MIGRATIONS', None,
                   'Dictionary for mapping alembic settings'),
         Parameter('DEFAULT_TEXT_SEARCH_CONFIG', 'english',
-                  'Default config/language for :search operator full-text '
-                  'search')
+                  'Default config/language for :search full-text search '
+                  'operator')
     ]
 
     def on_config(self, app):

--- a/release/notes.md
+++ b/release/notes.md
@@ -1,32 +1,3 @@
-* Development Status set to ``3 - Alpha``
-
 ## API
-* Better template directory for ``start_project`` command
-* ``style`` command create intermediary directories for the target css file
-* Removed the ``lux.extensions.cms`` module. No longer used
-* Added Registration views and backend models
-* Don't add OG metadata on response errors
-* Obfuscate javascript context dictionary using base64 encoding
 * RestModel
-  * get request correctly handles multiple args [[209](https://github.com/quantmind/lux/pull/209)]
-  * Add support for ``ne`` (not equals) and ``search`` operators  [[#212](https://github.com/quantmind/lux/pull/212)]
-  * ``search`` operator is the default operator for string columns in the javascript ``lux.grid`` component
-* Added new ``get_permissions`` method to backend base class and implemented in the ``auth`` backend
-* Permissions controlled via JSON documents with actions specified as
-  ``read``, ``update``, ``create`` and ``delete``. No more numeric values, only string allowed.
-  It is possible to set the wildcard ``*`` for allowing or denying all permissions
-  to a given resource
-* Admin sitemap method check for read permission if a backend is available and cache on per user basis
-* Use ``PASSWORD_SECRET_KEY`` for encrypting passwords
-
-## Javascript
-* Added scrollbar to sidebar [[214](https://github.com/quantmind/lux/pull/214)]
-* Clearfix in sidebar [[215](https://github.com/quantmind/lux/pull/215)]
-* Add ability to remember the selected link in sidebar submenus [[211](https://github.com/quantmind/lux/pull/221)]
-
-## Bug Fixes
-* Make sure ``MEDIA_URL`` does not end with a forward slash when adding the media router
-* Several fixes in the ``lux.extensions.rest.client``
-* Allows to display arrays in codemirror editor when in JSON mode [[#171](https://github.com/quantmind/lux/pull/171)]
-
-**329 unit tests**
+    * The ``:search`` operator now explicitly provides a full-text search config/language to PostgreSQL, allowing such queries to use available GIN/GiST indexes. This defaults to `english`, and can be overridden globally via the `DEFAULT_TEXT_SEARCH_CONFIG` parameter or per-column by passing `info={'text_search_config'='language'}` to `sqlalchemy.Column.__init__`. 


### PR DESCRIPTION
This explicitly provides the language/config to the `to_tsvector` PostgreSQL function used by the `:search` operator.

This is required for PostgeSQL to be able to use available GIN/GiST indexes in such queries. 

The config defaults to `english`, and can be overridden globally via the `DEFAULT_TEXT_SEARCH_CONFIG` parameter or per-column by e.g. `sa.Column(..., info={'text_search_config'='french'})`