### PR TITLE
Sidebar submenu's max-height is too small

### DIFF
--- a/lux/extensions/admin/sidebar.py
+++ b/lux/extensions/admin/sidebar.py
@@ -29,7 +29,7 @@ def add_css(all):
     sidebar.link.color = '#fff'
     sidebar.link.background = '#263647'
     #
-    sidebar.menu.max_height = px(999)
+    sidebar.menu.max_height = px(5000)
 
     trans = sidebar.transition
     # Why this? because unitary operations don't work yet and px(0) fails


### PR DESCRIPTION
The `max-height` css property has been set at 999px, increased here to 5000px as the current number of datasets on bmlltech.com was forcing the submenu over 999px.

Fixes #227.

<img width="240" alt="screen shot 2015-12-14 at 12 41 42" src="https://cloud.githubusercontent.com/assets/9137745/11781306/cfb5c944-a260-11e5-92c7-431ab8d82382.png">
