### PR TITLE
Don't append trailing slashes to links in breadcrumb directive

### DIFF
--- a/luxjs/page/page.js
+++ b/luxjs/page/page.js
@@ -98,7 +98,7 @@
                 path.split('/').forEach(function (name) {
                     if (name) {
                         last = {
-                            label: name.split('-').map(capitalize).join(' '),
+                            label: name.split(/[-_]+/).map(capitalize).join(' '),
                             href: joinUrl(last.href, name)
                         };
                         if (last.href.length >= lux.context.url.length)

--- a/luxjs/page/page.js
+++ b/luxjs/page/page.js
@@ -99,7 +99,7 @@
                     if (name) {
                         last = {
                             label: name.split('-').map(capitalize).join(' '),
-                            href: joinUrl(last.href, name+'/')
+                            href: joinUrl(last.href, name)
                         };
                         if (last.href.length >= lux.context.url.length)
                             steps.push(last);

--- a/release/notes.md
+++ b/release/notes.md
@@ -6,3 +6,6 @@
 * Api client is now a callable and requires the ``request`` object as first parameter.
   In this way the user agent and a possible token can be included in the api request
   [[233](https://github.com/quantmind/lux/pull/233)]
+
+## Directives
+* Breadcrumbs directive no longer appends trailing slashes to links [[#243](https://github.com/quantmind/lux/pull/243)]


### PR DESCRIPTION
This appears preferable to me as trailing slashes aren't generally used (e.g. default admin URL is `/admin`).